### PR TITLE
Add error when trying to use meatie_httpx.Client with httpx.AsyncClient

### DIFF
--- a/src/meatie_httpx/client.py
+++ b/src/meatie_httpx/client.py
@@ -27,6 +27,11 @@ class Client(BaseClient):
         limiter: Optional[Any] = None,
         prefix: Optional[str] = None,
     ) -> None:
+        if isinstance(client, httpx.AsyncClient):
+            raise NotImplementedError(
+                "Async HTTPX is not supported by the current version of Meatie."
+            )
+
         super().__init__(local_cache, limiter)
 
         self.client = client


### PR DESCRIPTION
As suggested in [this comment](https://github.com/pmateusz/meatie/issues/111#issuecomment-2585331535), I added an error when trying to use meatie_httpx.Client with httpx.AsyncClient. This is something which reallly threw me off when first trying to use meatie.